### PR TITLE
Fix node update and ensure system proxy use.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib/
 lib64/
 parts/
 sdist/
+dist/
 var/
 *.egg-info/
 .installed.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+tags

--- a/pydradis3/__init__.py
+++ b/pydradis3/__init__.py
@@ -22,6 +22,7 @@ import requests
 import string
 import json
 import shutil
+import urllib
 
 class Pydradis3:
     #End Nodes#
@@ -30,17 +31,21 @@ class Pydradis3:
     node_endpoint = "/pro/api/nodes"
     issue_endpoint = "/pro/api/issues"
     evidence_endpoint = "/pro/api/nodes/<ID>/evidence"
-    note_endpoint = "/pro/api/nodes/<ID>/notes" 
+    note_endpoint = "/pro/api/nodes/<ID>/notes"
     attachment_endpoint = "/pro/api/nodes/<ID>/attachments"
 
     #Constructor
-    def __init__(self, apiToken: str, url: str, debug=False, verify=True):
-        self.__apiToken = apiToken  #API Token 
+    def __init__(self, apiToken: str, url: str, debug=False, verify=True, proxies=None):
+        self.__apiToken = apiToken  #API Token
         self.__url = url            #Dradis URL (eg. https://your_dradis_server.com)
         self.__header = { 'Authorization':'Token token="' + self.__apiToken + '"'}
         self.__headerCt = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-type': 'application/json'}
         self.__debug = debug        #Debuging True?
-        self.__verify = verify      #Path to SSL certificate
+        self.__verify = verify      #Path to SSL certificate, or boolean, depending on validation requirements
+        if proxies is not None:
+            self.__proxies = proxies    #List of proxies to access the Dradis API
+        else:
+            self.__proxies = urllib.request.getproxies()
 
 
     def debug(self, val: bool):
@@ -53,7 +58,7 @@ class Pydradis3:
         r = r.prepare()
 
         s = requests.Session()
-        results = s.send(r)
+        results = s.send(r, proxies=self.__proxies)
 
         print(results)
         if (self.__debug):
@@ -71,7 +76,7 @@ class Pydradis3:
     #         Clients Endpoint         #
     ####################################
 
-    #Get Client List 
+    #Get Client List
     def get_clientlist(self):
         #URL
         url = self.__url + self.client_endpoint
@@ -89,48 +94,48 @@ class Pydradis3:
 
         return result
 
-    #Create Client 
+    #Create Client
     def create_client(self, client_name: str):
-        
+
         #URL
         url = self.__url + self.client_endpoint
-        
+
         #DATA
         data = {"client":{"name":client_name}}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__headerCt, "POST", "201", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id'] 
+        return r['id']
 
-    #Update Client 
+    #Update Client
     def update_client(self, client_id: str, new_client_name: str):
-        
+
         #URL
         url = self.__url + self.client_endpoint + "/" + str(client_id)
-        
+
         #DATA
         data = {"client":{"name":new_client_name}}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__headerCt, "PUT", "200", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id']      
+        return r['id']
 
-    #Delete Client 
+    #Delete Client
     def delete_client(self, client_id: str):
 
         #URL
         url = self.__url + self.client_endpoint + "/" + str(client_id)
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__header, "DELETE", "200")
 
@@ -140,7 +145,7 @@ class Pydradis3:
 
         return True
 
-    #Search For Client 
+    #Search For Client
     def find_client(self, name: str):
 
         #URL
@@ -157,10 +162,10 @@ class Pydradis3:
         for i in range(0, len(r)):
             if (r[i]["name"] == name):
                 return r[i]["id"]
-        
+
         return None
 
-    #Get Client Info 
+    #Get Client Info
     def get_client(self, client_id: str):
 
         #URL
@@ -172,7 +177,7 @@ class Pydradis3:
         #RETURN
         if (r == None):
             return None
-        
+
         return r
 
 
@@ -180,7 +185,7 @@ class Pydradis3:
     #         Projects Endpoint        #
     ####################################
 
-    #Get Project List 
+    #Get Project List
     def get_projectlist(self):
 
         #URL
@@ -199,9 +204,9 @@ class Pydradis3:
 
         return result
 
-    #Create Project 
+    #Create Project
     def create_project(self, project_name: str, client_id=None):
-        
+
         #URL
         url = self.__url + self.project_endpoint
 
@@ -209,22 +214,22 @@ class Pydradis3:
         data = {"project":{"name":project_name}}
         if (client_id != None):
             data = {"project":{"name":project_name, "client_id":str(client_id)}}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__headerCt, "POST", "201", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id'] 
+        return r['id']
 
-    #Update Project 
+    #Update Project
     def update_project(self, pid: int, new_project_name: str, new_client_id=None):
-        
+
         #URL
         url = self.__url + self.project_endpoint + "/" + str(pid)
-        
+
         #DATA
         data = {"project":{"name":new_project_name}}
         if (new_client_id != None):
@@ -233,19 +238,19 @@ class Pydradis3:
 
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__headerCt, "PUT", "200", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id']     
+        return r['id']
 
-    #Delete Project 
+    #Delete Project
     def delete_project(self, pid: int):
-        
+
         #URL
         url = self.__url + self.project_endpoint + "/" + str(pid)
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, self.__header, "DELETE", "200")
 
@@ -255,9 +260,9 @@ class Pydradis3:
 
         return True
 
-    #Search For Project 
+    #Search For Project
     def find_project(self, name: str):
-        
+
         #URL
         url = self.__url + self.project_endpoint
 
@@ -272,10 +277,10 @@ class Pydradis3:
         for i in range(0, len(r)):
             if (r[i]["name"] == name):
                 return r[i]["id"]
-        
+
         return None
 
-    #Get Project Info 
+    #Get Project Info
     def get_project(self, pid: int):
 
         #URL
@@ -287,7 +292,7 @@ class Pydradis3:
         #RETURN
         if (r == None):
             return None
-        
+
         return r
 
 
@@ -295,9 +300,9 @@ class Pydradis3:
     #         Nodes Endpoint           #
     ####################################
 
-    #Get Node List 
+    #Get Node List
     def get_nodelist(self, pid: int):
-        
+
         #URL
         url = self.__url + self.node_endpoint
 
@@ -317,7 +322,7 @@ class Pydradis3:
 
         return result
 
-    #Create Node 
+    #Create Node
     def create_node(self, pid: int, label: str, type_id=0, parent_id=None, position=1):
 
         #URL
@@ -325,24 +330,24 @@ class Pydradis3:
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
-        
+
         #DATA
         if (parent_id != None): #If None (Meaning its a toplevel node) then dont convert None to string.
             parent_id = str(parent_id)
         data = {"node":{"label":label, "type_id":str(type_id), "parent_id":parent_id, "position": str(position)}}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "POST", "201", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id'] 
+        return r['id']
 
-    #Update Node 
+    #Update Node
     def update_node(self, pid: int, node_id: str, label=None, type_id=None, parent_id=None, position=None):
-        
+
         #URL
         url = self.__url + self.node_endpoint + "/" + str(node_id)
 
@@ -351,7 +356,7 @@ class Pydradis3:
 
         #DATA (notice this time we are building a str not a dict)
         if (label==type_id==parent_id==position==None):
-            return None        
+            return None
 
         data = '{"node":{'
         if (label != None):
@@ -367,14 +372,14 @@ class Pydradis3:
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "PUT", "200", data)
-        
+
         #RETURN
         if (r == None):
             return None
 
-        return r['id']  
+        return r['id']
 
-    #Delete Node 
+    #Delete Node
     def delete_node(self, pid: int, node_id: str):
 
         #URL
@@ -382,7 +387,7 @@ class Pydradis3:
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
 
@@ -392,7 +397,7 @@ class Pydradis3:
 
         return True
 
-    #Find Node  :: Given a nodepath (e.g ac/dc/r) return the node id. (these change between projects) 
+    #Find Node  :: Given a nodepath (e.g ac/dc/r) return the node id. (these change between projects)
     def find_node(self, pid: int, nodepath: str):
 
         #URL
@@ -429,12 +434,12 @@ class Pydradis3:
 
         return parent_id
 
-    #Get Node Info 
+    #Get Node Info
     def get_node(self, pid: int, node_id: str):
 
         #URL
         url = self.__url + self.node_endpoint + "/" + str(node_id)
-        
+
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
 
@@ -444,7 +449,7 @@ class Pydradis3:
         #RETURN
         if (r == None):
             return None
-        
+
         return r
 
 
@@ -452,9 +457,9 @@ class Pydradis3:
     #         Issues Endpoint          #
     ####################################
 
-    #Get Issue List 
+    #Get Issue List
     def get_issuelist(self, pid: int):
-        
+
         #URL
         url = self.__url + self.issue_endpoint
 
@@ -474,7 +479,7 @@ class Pydradis3:
 
         return result
 
-    #Create Issue on Project 
+    #Create Issue on Project
     def create_issue(self, pid: int, title: str, text: str, tags=[]):
 
         #URL
@@ -521,9 +526,9 @@ class Pydradis3:
 
         return r['id']
 
-    #Update Issue 
+    #Update Issue
     def update_issue(self, pid: int, issue_id: str, title: str, text: str, tags=[]):
-        
+
         #URL
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
@@ -534,7 +539,7 @@ class Pydradis3:
         taglines = ""
         if (len(tags) != 0):
             for tag in tags:
-                taglines += "#[" + tag + "]#\r\n"    
+                taglines += "#[" + tag + "]#\r\n"
 
         data = { 'issue':{'text':'#[Title]#\r\n' + title + '\r\n\r\n#[Description]#\r\n' + str(text) + "\r\n\r\n" + taglines}}
 
@@ -606,15 +611,15 @@ class Pydradis3:
 
         return str(createIssue)
 
-    #Delete Issue 
+    #Delete Issue
     def delete_issue(self, pid: int, issue_id: str):
-        
+
         #URL
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
 
@@ -624,9 +629,9 @@ class Pydradis3:
 
         return True
 
-    #Find Issue 
+    #Find Issue
     def find_issue(self, pid: int, keywords: str):
-        
+
         #URL
         url = self.__url + self.issue_endpoint
 
@@ -655,7 +660,7 @@ class Pydradis3:
 
         return result
 
-    #Get Issue (with issue_id) 
+    #Get Issue (with issue_id)
     def get_issue(self, pid: int, issue_id: str):
 
         #URL
@@ -677,7 +682,7 @@ class Pydradis3:
     #         Evidence Endpoint        #
     ####################################
 
-    #Get Evidence List 
+    #Get Evidence List
     def get_evidencelist(self, pid: int, node_id: str):
 
         #URL
@@ -695,7 +700,7 @@ class Pydradis3:
 
         return r
 
-    #Create Evidence 
+    #Create Evidence
     def create_evidence(self, pid: int, node_id: str, issue_id: str, title: str, text: str, tags=[]):
 
         #URL
@@ -715,7 +720,7 @@ class Pydradis3:
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "POST", "201", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
@@ -743,7 +748,7 @@ class Pydradis3:
 
         return r['id']
 
-    #Update Evidence 
+    #Update Evidence
     def update_evidence(self, pid: int, node_id: str, issue_id: str, evidence_id: str, title: str, text: str, tags=[]):
 
         #URL
@@ -759,17 +764,17 @@ class Pydradis3:
                 taglines += "#[" + tag + "]#\r\n"
 
         data = { 'evidence':{'content':'#[Title]#\r\n' + title + '\r\n\r\n#[Description]#\r\n' + str(text) + "\r\n\r\n" + taglines, "issue_id":str(issue_id)}}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "PUT", "200", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
 
         return r['id']
 
-    #Delete Evidence 
+    #Delete Evidence
     def delete_evidence(self, pid: int, node_id: str, evidence_id: str):
 
         #URL
@@ -787,7 +792,7 @@ class Pydradis3:
 
         return True
 
-    #Find Evidence 
+    #Find Evidence
     def find_evidence(self, pid: int, node_id: str, keywords: str):
 
         #URL
@@ -818,7 +823,7 @@ class Pydradis3:
 
         return result
 
-    #Get Evidence Info 
+    #Get Evidence Info
     def get_evidence(self, pid: int, node_id: str, evidence_id: str):
 
         #URL
@@ -826,7 +831,7 @@ class Pydradis3:
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid)}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "GET", "200")
 
@@ -842,7 +847,7 @@ class Pydradis3:
     ####################################
 
 
-    #Get Note List 
+    #Get Note List
     def get_notelist(self, pid: int, node_id: str):
 
         #URL
@@ -864,9 +869,9 @@ class Pydradis3:
 
         return result
 
-    #Create a note on a project 
+    #Create a note on a project
     def create_note(self, pid: int, node_id: str, title: str, text: str, tags=[], category=0):
-        
+
         #URL
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id))
 
@@ -883,7 +888,7 @@ class Pydradis3:
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "POST", "201", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
@@ -911,7 +916,7 @@ class Pydradis3:
 
         return r['id']
 
-    #Update Note 
+    #Update Note
     def update_note(self, pid: int, node_id: str, note_id: str, title: str, text: str, tags=[], category=1):
 
         #URL
@@ -930,7 +935,7 @@ class Pydradis3:
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "PUT", "200", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None
@@ -963,7 +968,7 @@ class Pydradis3:
 
         return r['id']
 
-    #Delete Note 
+    #Delete Note
     def delete_note(self, pid: int, node_id: str, note_id: str):
 
         #URL
@@ -981,9 +986,9 @@ class Pydradis3:
 
         return True
 
-    #Find Note 
+    #Find Note
     def find_note(self, pid: int, node_id: str, keywords: str):
-        
+
         #URL
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id))
 
@@ -1013,7 +1018,7 @@ class Pydradis3:
 
         return result
 
-    #Get Note Info 
+    #Get Note Info
     def get_note(self, pid: int, node_id: str, note_id: str):
 
         #URL
@@ -1021,7 +1026,7 @@ class Pydradis3:
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid)}
-        
+
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "GET", "200")
 
@@ -1095,7 +1100,7 @@ class Pydradis3:
 
             #FILES
             files = [('files[]', open(attachment_filename, 'rb'))]
-            
+
             r = requests.post(url, headers=header, files=files, verify=self.__verify)
             if(r.status_code != 201):
                 return None
@@ -1114,13 +1119,13 @@ class Pydradis3:
 
         #HEADER
         header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-type': 'application/json', 'Dradis-Project-Id': str(pid)}
-        
+
         #DATA
         data = {"attachment":{"filename":new_attachment_name}}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "PUT", "200", json.dumps(data))
-        
+
         #RETURN
         if (r == None):
             return None

--- a/pydradis3/__init__.py
+++ b/pydradis3/__init__.py
@@ -39,7 +39,7 @@ class Pydradis3:
         self.__apiToken = apiToken  #API Token
         self.__url = url            #Dradis URL (eg. https://your_dradis_server.com)
         self.__header = { 'Authorization':'Token token="' + self.__apiToken + '"'}
-        self.__headerCt = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-type': 'application/json'}
+        self.__headerCt = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-Type': 'application/json'}
         self.__debug = debug        #Debuging True?
         self.__verify = verify      #Path to SSL certificate, or boolean, depending on validation requirements
         if proxies is not None:
@@ -333,7 +333,7 @@ class Pydradis3:
         url = self.__url + self.node_endpoint
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         if (parent_id != None): #If None (Meaning its a toplevel node) then dont convert None to string.
@@ -356,7 +356,7 @@ class Pydradis3:
         url = self.__url + self.node_endpoint + "/" + str(node_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA (notice this time we are building a str not a dict)
         if (label==type_id==parent_id==position==None):
@@ -402,7 +402,7 @@ class Pydradis3:
         url = self.__url + self.node_endpoint + "/" + str(node_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
@@ -420,7 +420,7 @@ class Pydradis3:
         url = self.__url + self.node_endpoint
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "GET", "200")
@@ -457,7 +457,7 @@ class Pydradis3:
         url = self.__url + self.node_endpoint + "/" + str(node_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "GET", "200")
@@ -502,7 +502,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -528,7 +528,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint
 
         #HEADER
-        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         data = {'issue': data}
@@ -549,7 +549,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -576,7 +576,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         data = {'issue': data}
@@ -597,7 +597,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         # Obtain original
         existingIssue = self.get_issue(pid=pid, issue_id=issue_id)
@@ -634,7 +634,7 @@ class Pydradis3:
         url = self.__url + self.issue_endpoint + "/" + str(issue_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
@@ -723,7 +723,7 @@ class Pydradis3:
         url = self.__url + self.evidence_endpoint.replace("<ID>", str(node_id))
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -750,7 +750,7 @@ class Pydradis3:
         url = self.__url + self.evidence_endpoint.replace("<ID>", str(node_id))
 
         #HEADER
-        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         data = {'evidence':{'content':data, "issue_id":str(issue_id)}}
@@ -771,7 +771,7 @@ class Pydradis3:
         url = self.__url + self.evidence_endpoint.replace("<ID>", str(node_id)) + "/" + str(evidence_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -797,7 +797,7 @@ class Pydradis3:
         url = self.__url + self.evidence_endpoint.replace("<ID>", str(node_id)) + "/" + str(evidence_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
@@ -892,7 +892,7 @@ class Pydradis3:
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id))
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -918,7 +918,7 @@ class Pydradis3:
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id))
 
         #HEADER
-        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = {'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         data = {'note':{'text':data}}
@@ -939,7 +939,7 @@ class Pydradis3:
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id)) + "/" + str(note_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -965,7 +965,7 @@ class Pydradis3:
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id)) + "/" + str(note_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #DATA
         taglines = ""
@@ -991,7 +991,7 @@ class Pydradis3:
         url = self.__url + self.note_endpoint.replace("<ID>", str(node_id)) + "/" + str(note_id)
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")
@@ -1134,7 +1134,7 @@ class Pydradis3:
         url = self.__url + self.attachment_endpoint.replace("<ID>", str(node_id)) + "/" + attachment_name
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-type': 'application/json', 'Dradis-Project-Id': str(pid)}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Content-Type': 'application/json', 'Dradis-Project-Id': str(pid)}
 
         #DATA
         data = {"attachment":{"filename":new_attachment_name}}
@@ -1154,7 +1154,7 @@ class Pydradis3:
         url = self.__url + self.attachment_endpoint.replace("<ID>", str(node_id)) + "/" + attachment_name
 
         #HEADER
-        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-type': 'application/json'}
+        header = { 'Authorization':'Token token="' + self.__apiToken + '"', 'Dradis-Project-Id': str(pid), 'Content-Type': 'application/json'}
 
         #CONTACT DRADIS
         r = self.contactDradis(url, header, "DELETE", "200")

--- a/pydradis3/__init__.py
+++ b/pydradis3/__init__.py
@@ -47,6 +47,9 @@ class Pydradis3:
         else:
             self.__proxies = urllib.request.getproxies()
 
+        if self.__debug:
+            print(f'Using proxies : {str(self.__proxies)}')
+
 
     def debug(self, val: bool):
         self.__debug = val
@@ -58,6 +61,7 @@ class Pydradis3:
         r = r.prepare()
 
         s = requests.Session()
+        s.verify = self.__verify
         results = s.send(r, proxies=self.__proxies)
 
         print(results)
@@ -359,14 +363,26 @@ class Pydradis3:
             return None
 
         data = '{"node":{'
+        # Prevent invalid data when updating only a single element
+        first=True
         if (label != None):
+            first=False
             data  += '"label":"' + label + '"'
         if (type_id != None):
-            data  += ', "type_id":"' + str(type_id) + '"'
+            if not first:
+                data +=', '
+                first = False
+            data  += '"type_id":"' + str(type_id) + '"'
         if (parent_id != None):
-            data  += ', "parent_id":"' + str(parent_id) + '"'
+            if not first:
+                data +=', '
+                first = False
+            data  += '"parent_id":"' + str(parent_id) + '"'
         if (position != None):
-            data  += ', "position":"' + str(position) + '"'
+            if not first:
+                data +=', '
+                first = False
+            data  += '"position":"' + str(position) + '"'
         data  += "}}"
 
 


### PR DESCRIPTION
The current `update_node` can only update a node in the following cases, either : 

* the label is the only updated value ;
* at least the label is updated at the same time as another field.

This is due to the way the request is constructed : 
```python
        data = '{"node":{'
        if (label != None):
            data  += '"label":"' + label + '"'
        if (type_id != None):
            data  += ', "type_id":"' + str(type_id) + '"'
        if (parent_id != None):
            data  += ', "parent_id":"' + str(parent_id) + '"'
        if (position != None):
            data  += ', "position":"' + str(position) + '"'
        data  += "}}"
```
If the label isn't updated, it results in the following request body (example for parent_id update), and a 400 Response: 
```
{
   "node" {
        ,
        "parent_id": "someID"
}}
```

I haven't checked the rest of the `update` functions, but one may assume the same behaviour may be implemented.
I'll get to it soon if that's the case.